### PR TITLE
Patch release to remove requirements duplication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit-embedcode",
-    version="0.1.1",
+    version="0.1.2",
     author="Randy Zwitch",
     author_email="randy@streamlit.io",
     description="Streamlit component for embedded code snippets",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=0.63
 pytest>=5.4
 seleniumbase
+streamlit-embedcode


### PR DESCRIPTION
Now that sharing supports requirements.txt in subfolders, remove from top-level requirements.txt